### PR TITLE
chore: update endpoint

### DIFF
--- a/deploy/deploy-greeter.ts
+++ b/deploy/deploy-greeter.ts
@@ -28,16 +28,6 @@ export default async function (hre: HardhatRuntimeEnvironment) {
   const greeting = "Hi there!";
   const deploymentFee = await deployer.estimateDeployFee(artifact, [greeting]);
 
-  // ⚠️ OPTIONAL: You can skip this block if your account already has funds in L2
-  // Deposit funds to L2
-  // const depositHandle = await deployer.zkWallet.deposit({
-  //   to: deployer.zkWallet.address,
-  //   token: utils.ETH_ADDRESS,
-  //   amount: deploymentFee.mul(2),
-  // });
-  // // Wait until the deposit is processed on zkSync
-  // await depositHandle.wait();
-
   // Deploy this contract. The returned object will be of a `Contract` type, similarly to ones in `ethers`.
   // `greeting` is an argument for contract constructor.
   const parsedFee = ethers.utils.formatEther(deploymentFee.toString());

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -14,7 +14,7 @@ const zkSyncTestnet =
         zksync: true,
       }
     : {
-        url: "https://zksync2-testnet.zksync.dev",
+        url: "https://testnet.era.zksync.dev",
         ethNetwork: "goerli",
         zksync: true,
         // contract verification endpoint


### PR DESCRIPTION
Changes introduced in this PR:
- Updates deprecated testnet endpoint
- Removes commented code for deposit bridging (sdk currently broken) 