### PR TITLE
add(sepolia): into the hardhat config file

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,14 +1,20 @@
-import { HardhatUserConfig } from "hardhat/config";
-
 import "@matterlabs/hardhat-zksync-node";
 import "@matterlabs/hardhat-zksync-deploy";
 import "@matterlabs/hardhat-zksync-solc";
 import "@matterlabs/hardhat-zksync-verify";
 
+import { HardhatUserConfig } from "hardhat/config";
+
 const config: HardhatUserConfig = {
-  defaultNetwork: "zkSyncTestnet",
+  defaultNetwork: "zkSyncTestnetSepolia",
   networks: {
-    zkSyncTestnet: {
+    zkSyncTestnetSepolia: {
+      url: "https://sepolia.era.zksync.dev",
+      ethNetwork: "sepolia",
+      zksync: true,
+      verifyURL: "https://explorer.sepolia.era.zksync.dev/contract_verification",
+    },
+    zkSyncTestnetGoerli: {
       url: "https://testnet.era.zksync.dev",
       ethNetwork: "goerli",
       zksync: true,


### PR DESCRIPTION
# What :computer: 
* `zkSyncTestnetSepolia` as the first option, and changed the defaultNetwork to `zkSyncTestnetSepolia`

# Why :hand:
* Migrating to Sepolia testnet

# Evidence :camera:
<img width="643" alt="Screenshot 2023-12-05 at 01 03 10" src="https://github.com/matter-labs/zksync-hardhat-template/assets/22985657/d1cf8d56-9a96-4ff7-8ab6-308952ecbe1d">

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?